### PR TITLE
Fix validateSignature import references to use extractCredentials

### DIFF
--- a/src/routes/auth/index.ts
+++ b/src/routes/auth/index.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { BaseRoute } from '../base-route';
 import { validateRequest } from '@/middleware/validation';
-import { requireAuth, validateSignature } from '@/middleware/auth';
+import { requireAuth, extractCredentials } from '@/middleware/auth';
 import Joi from 'joi';
 
 export class AuthRoutes extends BaseRoute {
@@ -40,7 +40,7 @@ export class AuthRoutes extends BaseRoute {
     );
 
     router.post('/action/init',
-      validateSignature,
+      extractCredentials,
       validateRequest({
         body: Joi.object({
           userActionPayload: Joi.string().required(),
@@ -53,7 +53,7 @@ export class AuthRoutes extends BaseRoute {
     );
 
     router.post('/action/sign',
-      validateSignature,
+      extractCredentials,
       validateRequest({
         body: Joi.object({
           challengeIdentifier: Joi.string().required(),

--- a/src/routes/fee-sponsors/index.ts
+++ b/src/routes/fee-sponsors/index.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { BaseRoute } from '../base-route';
 import { validateRequest } from '@/middleware/validation';
-import { requireAuth, validateSignature } from '@/middleware/auth';
+import { requireAuth, extractCredentials } from '@/middleware/auth';
 import Joi from 'joi';
 
 export class FeeSponsorRoutes extends BaseRoute {
@@ -10,7 +10,7 @@ export class FeeSponsorRoutes extends BaseRoute {
 
     router.post('/',
       requireAuth,
-      validateSignature,
+      extractCredentials,
       validateRequest({
         body: Joi.object({
           name: Joi.string().required(),
@@ -43,7 +43,7 @@ export class FeeSponsorRoutes extends BaseRoute {
 
     router.post('/:id/activate',
       requireAuth,
-      validateSignature,
+      extractCredentials,
       validateRequest({
         params: Joi.object({
           id: Joi.string().required(),
@@ -54,7 +54,7 @@ export class FeeSponsorRoutes extends BaseRoute {
 
     router.post('/:id/deactivate',
       requireAuth,
-      validateSignature,
+      extractCredentials,
       validateRequest({
         params: Joi.object({
           id: Joi.string().required(),
@@ -65,7 +65,7 @@ export class FeeSponsorRoutes extends BaseRoute {
 
     router.delete('/:id',
       requireAuth,
-      validateSignature,
+      extractCredentials,
       validateRequest({
         params: Joi.object({
           id: Joi.string().required(),

--- a/src/routes/keys/index.ts
+++ b/src/routes/keys/index.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { BaseRoute } from '../base-route';
 import { validateRequest } from '@/middleware/validation';
-import { requireAuth, validateSignature } from '@/middleware/auth';
+import { requireAuth, extractCredentials } from '@/middleware/auth';
 import Joi from 'joi';
 
 export class KeyRoutes extends BaseRoute {
@@ -10,7 +10,7 @@ export class KeyRoutes extends BaseRoute {
 
     router.post('/',
       requireAuth,
-      validateSignature,
+      extractCredentials,
       validateRequest({
         body: Joi.object({
           scheme: Joi.string().required(),
@@ -60,7 +60,7 @@ export class KeyRoutes extends BaseRoute {
 
     router.delete('/:id',
       requireAuth,
-      validateSignature,
+      extractCredentials,
       validateRequest({
         params: Joi.object({
           id: Joi.string().required(),
@@ -71,7 +71,7 @@ export class KeyRoutes extends BaseRoute {
 
     router.post('/:id/delegate',
       requireAuth,
-      validateSignature,
+      extractCredentials,
       validateRequest({
         params: Joi.object({
           id: Joi.string().required(),
@@ -85,7 +85,7 @@ export class KeyRoutes extends BaseRoute {
 
     router.post('/:id/signatures',
       requireAuth,
-      validateSignature,
+      extractCredentials,
       validateRequest({
         params: Joi.object({
           id: Joi.string().required(),

--- a/src/routes/permissions/index.ts
+++ b/src/routes/permissions/index.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { BaseRoute } from '../base-route';
 import { validateRequest } from '@/middleware/validation';
-import { requireAuth, validateSignature } from '@/middleware/auth';
+import { requireAuth, extractCredentials } from '@/middleware/auth';
 import Joi from 'joi';
 
 export class PermissionRoutes extends BaseRoute {
@@ -21,7 +21,7 @@ export class PermissionRoutes extends BaseRoute {
 
     router.post('/permissions',
       requireAuth,
-      validateSignature,
+      extractCredentials,
       validateRequest({
         body: Joi.object({
           name: Joi.string().required(),
@@ -46,7 +46,7 @@ export class PermissionRoutes extends BaseRoute {
 
     router.put('/permissions/:id',
       requireAuth,
-      validateSignature,
+      extractCredentials,
       validateRequest({
         params: Joi.object({
           id: Joi.string().required(),
@@ -64,7 +64,7 @@ export class PermissionRoutes extends BaseRoute {
 
     router.delete('/permissions/:id',
       requireAuth,
-      validateSignature,
+      extractCredentials,
       validateRequest({
         params: Joi.object({
           id: Joi.string().required(),
@@ -87,7 +87,7 @@ export class PermissionRoutes extends BaseRoute {
 
     router.post('/user-permissions',
       requireAuth,
-      validateSignature,
+      extractCredentials,
       validateRequest({
         body: Joi.object({
           userId: Joi.string().required(),
@@ -100,7 +100,7 @@ export class PermissionRoutes extends BaseRoute {
 
     router.delete('/user-permissions/:userId/:permissionId',
       requireAuth,
-      validateSignature,
+      extractCredentials,
       validateRequest({
         params: Joi.object({
           userId: Joi.string().required(),
@@ -124,7 +124,7 @@ export class PermissionRoutes extends BaseRoute {
 
     router.post('/role-permissions',
       requireAuth,
-      validateSignature,
+      extractCredentials,
       validateRequest({
         body: Joi.object({
           roleId: Joi.string().required(),
@@ -136,7 +136,7 @@ export class PermissionRoutes extends BaseRoute {
 
     router.delete('/role-permissions/:roleId/:permissionId',
       requireAuth,
-      validateSignature,
+      extractCredentials,
       validateRequest({
         params: Joi.object({
           roleId: Joi.string().required(),

--- a/src/routes/policy-engine/index.ts
+++ b/src/routes/policy-engine/index.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { BaseRoute } from '../base-route';
 import { validateRequest } from '@/middleware/validation';
-import { requireAuth, validateSignature } from '@/middleware/auth';
+import { requireAuth, extractCredentials } from '@/middleware/auth';
 import Joi from 'joi';
 
 export class PolicyEngineRoutes extends BaseRoute {
@@ -21,7 +21,7 @@ export class PolicyEngineRoutes extends BaseRoute {
 
     router.post('/policies',
       requireAuth,
-      validateSignature,
+      extractCredentials,
       validateRequest({
         body: Joi.object({
           name: Joi.string().required(),
@@ -49,7 +49,7 @@ export class PolicyEngineRoutes extends BaseRoute {
 
     router.put('/policies/:id',
       requireAuth,
-      validateSignature,
+      extractCredentials,
       validateRequest({
         params: Joi.object({
           id: Joi.string().required(),
@@ -71,7 +71,7 @@ export class PolicyEngineRoutes extends BaseRoute {
 
     router.delete('/policies/:id',
       requireAuth,
-      validateSignature,
+      extractCredentials,
       validateRequest({
         params: Joi.object({
           id: Joi.string().required(),
@@ -104,7 +104,7 @@ export class PolicyEngineRoutes extends BaseRoute {
 
     router.post('/approval-requests/:id/approve',
       requireAuth,
-      validateSignature,
+      extractCredentials,
       validateRequest({
         params: Joi.object({
           id: Joi.string().required(),
@@ -115,7 +115,7 @@ export class PolicyEngineRoutes extends BaseRoute {
 
     router.post('/approval-requests/:id/reject',
       requireAuth,
-      validateSignature,
+      extractCredentials,
       validateRequest({
         params: Joi.object({
           id: Joi.string().required(),

--- a/src/routes/wallets/index.ts
+++ b/src/routes/wallets/index.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { BaseRoute } from '../base-route';
 import { validateRequest } from '@/middleware/validation';
-import { requireAuth, validateSignature } from '@/middleware/auth';
+import { requireAuth, extractCredentials } from '@/middleware/auth';
 import Joi from 'joi';
 
 export class WalletRoutes extends BaseRoute {
@@ -10,7 +10,7 @@ export class WalletRoutes extends BaseRoute {
 
     router.post('/',
       requireAuth,
-      validateSignature,
+      extractCredentials,
       validateRequest({
         body: Joi.object({
           network: Joi.string().required(),
@@ -59,7 +59,7 @@ export class WalletRoutes extends BaseRoute {
 
     router.delete('/:id',
       requireAuth,
-      validateSignature,
+      extractCredentials,
       validateRequest({
         params: Joi.object({
           id: Joi.string().required(),
@@ -70,7 +70,7 @@ export class WalletRoutes extends BaseRoute {
 
     router.post('/:id/delegate',
       requireAuth,
-      validateSignature,
+      extractCredentials,
       validateRequest({
         params: Joi.object({
           id: Joi.string().required(),
@@ -148,7 +148,7 @@ export class WalletRoutes extends BaseRoute {
 
     router.post('/:id/transfers',
       requireAuth,
-      validateSignature,
+      extractCredentials,
       validateRequest({
         params: Joi.object({
           id: Joi.string().required(),
@@ -198,7 +198,7 @@ export class WalletRoutes extends BaseRoute {
 
     router.post('/:id/transactions',
       requireAuth,
-      validateSignature,
+      extractCredentials,
       validateRequest({
         params: Joi.object({
           id: Joi.string().required(),

--- a/src/routes/webhooks/index.ts
+++ b/src/routes/webhooks/index.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { BaseRoute } from '../base-route';
 import { validateRequest } from '@/middleware/validation';
-import { requireAuth, validateSignature } from '@/middleware/auth';
+import { requireAuth, extractCredentials } from '@/middleware/auth';
 import Joi from 'joi';
 
 export class WebhookRoutes extends BaseRoute {
@@ -10,7 +10,7 @@ export class WebhookRoutes extends BaseRoute {
 
     router.post('/',
       requireAuth,
-      validateSignature,
+      extractCredentials,
       validateRequest({
         body: Joi.object({
           name: Joi.string().required(),
@@ -45,7 +45,7 @@ export class WebhookRoutes extends BaseRoute {
 
     router.put('/:id',
       requireAuth,
-      validateSignature,
+      extractCredentials,
       validateRequest({
         params: Joi.object({
           id: Joi.string().required(),
@@ -63,7 +63,7 @@ export class WebhookRoutes extends BaseRoute {
 
     router.delete('/:id',
       requireAuth,
-      validateSignature,
+      extractCredentials,
       validateRequest({
         params: Joi.object({
           id: Joi.string().required(),


### PR DESCRIPTION
- Updated all route files to import extractCredentials instead of validateSignature
- Replaced validateSignature middleware usage with extractCredentials in route chains
- Resolves TypeScript compilation errors: TS2305 Module has no exported member validateSignature